### PR TITLE
Fix: get user could return undefined

### DIFF
--- a/src/stores/context.store.ts
+++ b/src/stores/context.store.ts
@@ -173,7 +173,7 @@ class AppContext {
     }
 
     private ensureUsers() {
-        if (!this.context.value.users || this.context.value.users.length < 1) {
+        if (!this.context.value.users || this.context.value.users.length === 0) {
             this.context.value.users = [UserFactory.anonymous()];
         }
 

--- a/src/stores/context.store.ts
+++ b/src/stores/context.store.ts
@@ -173,7 +173,7 @@ class AppContext {
     }
 
     private ensureUsers() {
-        if (!this.context.value.users) {
+        if (!this.context.value.users || this.context.value.users.length < 1) {
             this.context.value.users = [UserFactory.anonymous()];
         }
 


### PR DESCRIPTION
`{
    "datasets": [
        {
            "displayName": "testtest",
            "apiKey": "XXXX",
            "datasetId": "c5847c93-04b3-4f11-b743-9427690a6de2",
            "currencyCode": "NOK",
            "language": "no",
            "users": [],
            "companies": [],
            "selectedUserIndex": 0,
            "serverUrl": "https://sandbox-api.relewise.com/"
        }
    ],
    "selectedDatasetIndex": 0,
    "tracking": {
        "enabled": false
    }
}`


You can test this by putting ^^ directly in your context in local storage. Having this config will cause prod to fail!

