### PR TITLE
Fix: refreshing on PLP will still keep overlay open

### DIFF
--- a/src/views/Category.vue
+++ b/src/views/Category.vue
@@ -191,7 +191,7 @@ async function search() {
         })
         .build();
 
-    const query = { ...filters.value };
+    const query = { ...router.currentRoute.value.query, ...filters.value };
     if (!applySalesPriceFacet) delete query.price;
 
     await router.push({ path: route.path, query: query });


### PR DESCRIPTION
https://trello.com/c/lWRUVe5v/8031-demoshop-when-having-the-search-overlay-open-on-a-category-page-and-then-refresh-the-page-the-search-overlay-does-not-open-again?filter=member:simonwalenkamphansen