### PR TITLE
Show authenticated users with email labels in dropdowns

### DIFF
--- a/src/components/Personalization.vue
+++ b/src/components/Personalization.vue
@@ -99,6 +99,7 @@ import ConfirmationDialog from '@/components/ConfirmationDialog.vue';
 import SettingsPanel from '@/components/settings/SettingsPanel.vue';
 import CompanyEditorCard from '@/components/settings/CompanyEditorCard.vue';
 import UserEditorCard from '@/components/settings/UserEditorCard.vue';
+import { displayUser } from '@/helpers/userHelper';
 import contextStore, { type IDataset } from '@/stores/context.store';
 import { UserFactory, type Company, type User } from '@relewise/client';
 import { computed, nextTick, ref, watch } from 'vue';
@@ -248,7 +249,8 @@ function confirmRemoveCompany() {
 }
 
 function userKey(user: User, index: number) {
-    return user.authenticatedId || user.temporaryId || user.email || `user-${index}`;
+    const label = displayUser(user);
+    return label !== 'Anonymous' ? label : `user-${index}`;
 }
 
 function toggleUserExpanded(index: number) {

--- a/src/components/settings/UserEditorCard.vue
+++ b/src/components/settings/UserEditorCard.vue
@@ -120,6 +120,7 @@ import InputText from '@/components/form/InputText.vue';
 import TrashCanButton from '@/components/form/TrashCanButton.vue';
 import KeyValues, { type KeyValue } from '@/components/KeyValues.vue';
 import { keyValueArrayToDataRecord, keyValueArrayToStringRecord, keyValuesFromDataRecord, keyValuesFromStringRecord, setUserMetadataDraft } from '@/helpers/keyValueMetadata';
+import { displayUser } from '@/helpers/userHelper';
 import { ChevronDownIcon } from '@heroicons/vue/24/outline';
 import type { User } from '@relewise/client';
 import { computed, ref, watch } from 'vue';
@@ -152,39 +153,22 @@ const identifierValues = computed(() => {
         .map((entry) => formatBadgeValue(entry.key, entry.value));
 });
 
-const headlineSource = computed<'authenticated' | 'email' | 'identifier' | 'temporary' | 'anonymous'>(() => {
-    if (authenticatedId.value.trim()) {
-        return 'authenticated';
-    }
+const headline = computed(() => {
+    const preferredLabel = displayUser({
+        email: email.value.trim() || undefined,
+        authenticatedId: authenticatedId.value.trim() || undefined,
+        temporaryId: temporaryId.value.trim() || undefined,
+    } as User);
 
-    if (email.value.trim()) {
-        return 'email';
+    if (preferredLabel !== 'Anonymous') {
+        return preferredLabel;
     }
 
     if (identifierValues.value.length > 0) {
-        return 'identifier';
+        return identifierValues.value.join(', ');
     }
 
-    if (temporaryId.value.trim()) {
-        return 'temporary';
-    }
-
-    return 'anonymous';
-});
-
-const headline = computed(() => {
-    switch (headlineSource.value) {
-        case 'authenticated':
-            return authenticatedId.value.trim();
-        case 'email':
-            return email.value.trim();
-        case 'identifier':
-            return identifierValues.value.join(', ');
-        case 'temporary':
-            return temporaryId.value.trim();
-        default:
-            return 'Anonymous user';
-    }
+    return 'Anonymous user';
 });
 
 const authenticatedIdActionLabel = computed(() => authenticatedId.value.trim() ? 'Regenerate' : 'Generate');

--- a/src/helpers/userHelper.ts
+++ b/src/helpers/userHelper.ts
@@ -3,11 +3,13 @@ import type { User } from '@relewise/client';
 export const displayUser = (user: User | null | undefined) => {
     if (!user) return '';
 
+    if (user.email)
+        return user.authenticatedId
+            ? `${user.email} (${user.authenticatedId})`
+            : user.email;
+
     if (user.authenticatedId)
         return user.authenticatedId;
-
-    if (user.email)
-        return user.email;
 
     if (user.temporaryId)
         return user.temporaryId;


### PR DESCRIPTION
https://trello.com/c/hRCQhorc/19769-demo-authenticated-users-in-the-dropdown-are-rendered-as-guids-not-email

## Summary
- prefer email labels for authenticated users and include the authenticated id as context
- reuse the shared user display helper in the user editor headline
- reuse the same display logic when generating user row keys in personalization

## Validation
- npm run type-check