### PR TITLE
Fix user/company context switching regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+/.vs

--- a/src/components/ContextSwitcher.vue
+++ b/src/components/ContextSwitcher.vue
@@ -3,6 +3,7 @@ import { createSessionSelectionsForDataset } from '@/helpers/contextSession';
 import { computed, ref, watch } from 'vue';
 import contextStore from '@/stores/context.store';
 import { displayUserOption } from '@/helpers/userHelper';
+import { getSelectableCompanyIdsForUser, hasSelectableCompaniesForUser } from '@/helpers/contextSession';
 import { Cog6ToothIcon } from '@heroicons/vue/24/outline';
 import router from '@/router';
 import InputSelect from '@/components/form/InputSelect.vue';
@@ -17,6 +18,19 @@ const draftSelectedCompanyOption = ref('');
 const draftDataset = computed(() => {
     return datasets.value.find((dataset) => dataset.datasetId === draftDatasetId.value);
 });
+const availableUserOptions = computed(() => {
+    return (draftDataset.value?.users ?? [])
+        .map((user, index) => ({ user, index }))
+        .filter(({ user }) => hasSelectableCompaniesForUser(user, draftDataset.value));
+});
+const availableCompanyOptions = computed(() => {
+    if (!draftDataset.value || draftSelectedUserOption.value === '') {
+        return [];
+    }
+
+    const selectedUser = draftDataset.value.users?.[Number(draftSelectedUserOption.value)];
+    return getSelectableCompanyIdsForUser(selectedUser, draftDataset.value);
+});
 const configureDemoRoute = computed(() => {
     if (!contextStore.hasActiveDataset.value) {
         return { name: 'settings' as const };
@@ -30,6 +44,17 @@ const configureDemoRoute = computed(() => {
 
 const hasUsers = computed(() => (draftDataset.value?.users?.length ?? 0) > 0);
 const hasCompanies = computed(() => (draftDataset.value?.companies?.length ?? 0) > 0);
+const isDraftSelectionValid = computed(() => {
+    if (!draftDataset.value) {
+        return false;
+    }
+
+    if (draftSelectedUserOption.value === '') {
+        return true;
+    }
+
+    return availableCompanyOptions.value.includes(draftSelectedCompanyOption.value);
+});
 
 watch(
     () => contextStore.activeContextRevision.value,
@@ -82,6 +107,19 @@ function setDataset(datasetId: string) {
 
 function setUser(selectedIndex: string) {
     draftSelectedUserOption.value = selectedIndex;
+
+    if (selectedIndex === '') {
+        draftSelectedCompanyOption.value = '';
+        return;
+    }
+
+    const nextAvailableCompanyOptions = availableCompanyOptions.value;
+    if (nextAvailableCompanyOptions.length === 1) {
+        draftSelectedCompanyOption.value = nextAvailableCompanyOptions[0];
+        return;
+    }
+
+    draftSelectedCompanyOption.value = '';
 }
 
 function setCompany(companyToSet: string) {
@@ -97,7 +135,7 @@ function changeCurrency(currency: string) {
 }
 
 async function applyContextChanges() {
-    if (!draftDataset.value) {
+    if (!draftDataset.value || !isDraftSelectionValid.value) {
         return;
     }
 
@@ -179,7 +217,7 @@ async function applyContextChanges() {
       <div class="flex-grow">
         <InputSelect
           label="User"
-          :disabled="!hasUsers"
+          :disabled="!hasUsers || availableUserOptions.length === 0"
           :model-value="draftSelectedUserOption"
           @update:model-value="setUser"
         >
@@ -187,32 +225,33 @@ async function applyContextChanges() {
             (None)
           </option>
           <option
-            v-for="(userOption, index) in draftDataset?.users ?? []"
-            :key="index"
-            :value="String(index)"
+            v-for="userOption in availableUserOptions"
+            :key="userOption.index"
+            :value="String(userOption.index)"
           >
-            {{ displayUserOption(userOption, index) }}
+            {{ displayUserOption(userOption.user, userOption.index) }}
           </option>
         </InputSelect>
       </div>
       <div
-        v-if="hasCompanies"
+        v-if="hasCompanies && draftSelectedUserOption !== ''"
         class="flex-grow"
       >
         <InputSelect
           label="Company"
+          :disabled="availableCompanyOptions.length === 0"
           :model-value="draftSelectedCompanyOption"
           @update:model-value="setCompany"
         >
           <option value="">
-            (None)
+            {{ availableCompanyOptions.length > 1 ? 'Select company' : '(None)' }}
           </option>
           <option
-            v-for="(companyOption, index) in draftDataset?.companies ?? []"
-            :key="index"
-            :value="companyOption.id"
+            v-for="companyOption in availableCompanyOptions"
+            :key="companyOption"
+            :value="companyOption"
           >
-            {{ companyOption.id }}
+            {{ companyOption }}
           </option>
         </InputSelect>
       </div>
@@ -227,7 +266,10 @@ async function applyContextChanges() {
           </div>
         </RouterLink>
         <button
+          v-close-popper
           class="ml-auto"
+          :disabled="!isDraftSelectionValid"
+          :class="!isDraftSelectionValid ? 'cursor-not-allowed opacity-60' : ''"
           @click="applyContextChanges"
         >
           Apply

--- a/src/components/ContextSwitcher.vue
+++ b/src/components/ContextSwitcher.vue
@@ -3,7 +3,7 @@ import { createSessionSelectionsForDataset } from '@/helpers/contextSession';
 import { computed, ref, watch } from 'vue';
 import contextStore from '@/stores/context.store';
 import { displayUserOption } from '@/helpers/userHelper';
-import { getSelectableCompanyIdsForUser, hasSelectableCompaniesForUser } from '@/helpers/contextSession';
+import { getSelectableCompanyIdsForUser } from '@/helpers/contextSession';
 import { Cog6ToothIcon } from '@heroicons/vue/24/outline';
 import router from '@/router';
 import InputSelect from '@/components/form/InputSelect.vue';
@@ -20,8 +20,7 @@ const draftDataset = computed(() => {
 });
 const availableUserOptions = computed(() => {
     return (draftDataset.value?.users ?? [])
-        .map((user, index) => ({ user, index }))
-        .filter(({ user }) => hasSelectableCompaniesForUser(user, draftDataset.value));
+        .map((user, index) => ({ user, index }));
 });
 const availableCompanyOptions = computed(() => {
     if (!draftDataset.value || draftSelectedUserOption.value === '') {
@@ -53,7 +52,11 @@ const isDraftSelectionValid = computed(() => {
         return true;
     }
 
-    return availableCompanyOptions.value.includes(draftSelectedCompanyOption.value);
+    if (availableCompanyOptions.value.length === 0) {
+        return true;
+    }
+
+    return draftSelectedCompanyOption.value === '' || availableCompanyOptions.value.includes(draftSelectedCompanyOption.value);
 });
 
 watch(
@@ -217,7 +220,7 @@ async function applyContextChanges() {
       <div class="flex-grow">
         <InputSelect
           label="User"
-          :disabled="!hasUsers || availableUserOptions.length === 0"
+          :disabled="!hasUsers"
           :model-value="draftSelectedUserOption"
           @update:model-value="setUser"
         >
@@ -234,17 +237,16 @@ async function applyContextChanges() {
         </InputSelect>
       </div>
       <div
-        v-if="hasCompanies && draftSelectedUserOption !== ''"
+        v-if="hasCompanies && draftSelectedUserOption !== '' && availableCompanyOptions.length > 0"
         class="flex-grow"
       >
         <InputSelect
           label="Company"
-          :disabled="availableCompanyOptions.length === 0"
           :model-value="draftSelectedCompanyOption"
           @update:model-value="setCompany"
         >
           <option value="">
-            {{ availableCompanyOptions.length > 1 ? 'Select company' : '(None)' }}
+            (None)
           </option>
           <option
             v-for="companyOption in availableCompanyOptions"

--- a/src/components/ContextSwitcher.vue
+++ b/src/components/ContextSwitcher.vue
@@ -232,7 +232,7 @@ async function applyContextChanges() {
             :key="userOption.index"
             :value="String(userOption.index)"
           >
-            {{ displayUserOption(userOption.user, userOption.index) }}
+            {{ displayUserOption(userOption.user, userOption.index, draftDataset?.users ?? []) }}
           </option>
         </InputSelect>
       </div>

--- a/src/components/Personalization.vue
+++ b/src/components/Personalization.vue
@@ -31,6 +31,8 @@
             :expanded="expandedUserIndexes.includes(index)"
             :is-active="props.dataset.datasetId === activeDatasetId && index === activeUserIndex"
             :user="userOption"
+            :user-index="index"
+            :users="users"
             @remove="deleteUser(index)"
             @toggle-expand="toggleUserExpanded(index)"
           />
@@ -101,7 +103,7 @@ import ConfirmationDialog from '@/components/ConfirmationDialog.vue';
 import SettingsPanel from '@/components/settings/SettingsPanel.vue';
 import CompanyEditorCard from '@/components/settings/CompanyEditorCard.vue';
 import UserEditorCard from '@/components/settings/UserEditorCard.vue';
-import { displayUser } from '@/helpers/userHelper';
+import { displayUserOption } from '@/helpers/userHelper';
 import { getUserCompanyIds, setUserCompanyIds } from '@/helpers/userContext';
 import contextStore, { type IDataset } from '@/stores/context.store';
 import { UserFactory, type Company, type User } from '@relewise/client';
@@ -258,8 +260,7 @@ function confirmRemoveCompany() {
 }
 
 function userKey(user: User, index: number) {
-    const label = displayUser(user);
-    return label !== 'Anonymous' ? label : `user-${index}`;
+    return displayUserOption(user, index, users.value);
 }
 
 function toggleUserExpanded(index: number) {

--- a/src/components/Personalization.vue
+++ b/src/components/Personalization.vue
@@ -27,6 +27,7 @@
           :ref="(element) => setUserCardRef(element, index)"
         >
           <UserEditorCard
+            :companies="companies"
             :expanded="expandedUserIndexes.includes(index)"
             :is-active="props.dataset.datasetId === activeDatasetId && index === activeUserIndex"
             :user="userOption"
@@ -68,6 +69,7 @@
             :company="companyOption"
             :expanded="expandedCompanyIndexes.includes(index)"
             :is-active="props.dataset.datasetId === activeDatasetId && companyOption.id === activeContextCompanyId"
+            :users="users"
             @remove="deleteCompany(index)"
             @toggle-expand="toggleCompanyExpanded(index)"
           />
@@ -100,6 +102,7 @@ import SettingsPanel from '@/components/settings/SettingsPanel.vue';
 import CompanyEditorCard from '@/components/settings/CompanyEditorCard.vue';
 import UserEditorCard from '@/components/settings/UserEditorCard.vue';
 import { displayUser } from '@/helpers/userHelper';
+import { getUserCompanyIds, setUserCompanyIds } from '@/helpers/userContext';
 import contextStore, { type IDataset } from '@/stores/context.store';
 import { UserFactory, type Company, type User } from '@relewise/client';
 import { computed, nextTick, ref, watch } from 'vue';
@@ -241,6 +244,12 @@ function confirmRemoveCompany() {
 
             return company;
         });
+    if (companyIdToRemove) {
+        props.dataset.users = users.value.map((user) => {
+            setUserCompanyIds(user, getUserCompanyIds(user).filter((companyId) => companyId !== companyIdToRemove));
+            return user;
+        });
+    }
 
     expandedCompanyIndexes.value = expandedCompanyIndexes.value
         .filter((expandedIndex) => expandedIndex !== index)
@@ -281,7 +290,8 @@ function isBlankAnonymousUser(user: User | undefined) {
         && !user.temporaryId
         && Object.keys(user.identifiers ?? {}).length === 0
         && Object.keys(user.classifications ?? {}).length === 0
-        && Object.keys(user.data ?? {}).length === 0;
+        && Object.keys(user.data ?? {}).length === 0
+        && getUserCompanyIds(user).length === 0;
 }
 
 function isBlankCompany(company: Company | undefined) {

--- a/src/components/form/InputTagSelect.vue
+++ b/src/components/form/InputTagSelect.vue
@@ -1,0 +1,184 @@
+<template>
+  <div class="relative">
+    <label
+      v-if="label"
+      class="block text-sm text-slate-700"
+    >
+      {{ label }}
+    </label>
+
+    <div class="mt-1 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 shadow-sm transition focus-within:border-brand-500 focus-within:bg-white focus-within:ring-2 focus-within:ring-brand-200">
+      <div class="flex flex-wrap items-center gap-2">
+        <span
+          v-for="item in selectedItems"
+          :key="item"
+          class="inline-flex items-center gap-1 rounded-md bg-white px-2.5 py-1 text-sm font-medium text-slate-700 ring-1 ring-slate-200"
+        >
+          <span>{{ item }}</span>
+          <button
+            type="button"
+            class="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-sm !bg-transparent !px-0 !py-0 !text-slate-400 !shadow-none transition hover:!bg-slate-200 hover:!text-slate-600"
+            :title="`Remove ${item}`"
+            :aria-label="`Remove ${item}`"
+            @click="removeItem(item)"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              class="h-3 w-3"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 4L12 12M12 4L4 12"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+        </span>
+
+        <input
+          ref="inputRef"
+          v-model="query"
+          type="text"
+          :placeholder="placeholder"
+          :disabled="disabled"
+          class="h-7 min-w-[7rem] flex-1 !border-0 !bg-transparent !px-0 !py-0 text-sm text-slate-900 !shadow-none placeholder:text-slate-400 focus:!ring-0 disabled:cursor-not-allowed disabled:text-slate-400"
+          @focus="isFocused = true"
+          @blur="handleBlur"
+          @keydown.enter.prevent="selectFirstFilteredOption"
+          @keydown.backspace="handleBackspace"
+          @keydown.esc.prevent="closeDropdown"
+        >
+      </div>
+    </div>
+
+    <div
+      v-if="showDropdown"
+      class="absolute z-20 mt-2 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white py-2 shadow-xl ring-1 ring-slate-100"
+    >
+      <button
+        v-for="option in filteredOptions"
+        :key="option"
+        type="button"
+        class="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-100"
+        @mousedown.prevent="addItem(option)"
+      >
+        <span class="truncate">{{ option }}</span>
+      </button>
+    </div>
+
+    <p
+      v-if="help"
+      class="mt-2 text-sm text-slate-600"
+    >
+      {{ help }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+const props = withDefaults(defineProps<{
+    modelValue: string[];
+    options: string[];
+    label?: string;
+    help?: string;
+    placeholder?: string;
+    disabled?: boolean;
+}>(), {
+    label: '',
+    help: '',
+    placeholder: '',
+    disabled: false,
+});
+
+const emit = defineEmits<{
+    'update:modelValue': [value: string[]];
+}>();
+
+const inputRef = ref<HTMLInputElement | null>(null);
+const isFocused = ref(false);
+const query = ref('');
+
+const normalizedOptions = computed(() => normalizeValues(props.options ?? []));
+const selectedItems = computed(() => normalizeValues(props.modelValue ?? []));
+const filteredOptions = computed(() => {
+    const normalizedQuery = query.value.trim().toLowerCase();
+
+    return normalizedOptions.value.filter((option) => {
+        if (selectedItems.value.includes(option)) {
+            return false;
+        }
+
+        if (!normalizedQuery) {
+            return true;
+        }
+
+        return option.toLowerCase().includes(normalizedQuery);
+    });
+});
+const showDropdown = computed(() => isFocused.value && !props.disabled && filteredOptions.value.length > 0);
+
+function addItem(option: string) {
+    const normalizedOption = normalizedOptions.value.find((value) => value.toLowerCase() === option.toLowerCase());
+    if (!normalizedOption || selectedItems.value.includes(normalizedOption)) {
+        query.value = '';
+        return;
+    }
+
+    emit('update:modelValue', [...selectedItems.value, normalizedOption]);
+    query.value = '';
+    inputRef.value?.focus();
+}
+
+function removeItem(option: string) {
+    emit('update:modelValue', selectedItems.value.filter((value) => value !== option));
+}
+
+function selectFirstFilteredOption() {
+    if (filteredOptions.value.length === 0) {
+        return;
+    }
+
+    addItem(filteredOptions.value[0]);
+}
+
+function handleBackspace(event: KeyboardEvent) {
+    if (query.value || selectedItems.value.length === 0) {
+        return;
+    }
+
+    event.preventDefault();
+    emit('update:modelValue', selectedItems.value.slice(0, -1));
+}
+
+function handleBlur() {
+    window.setTimeout(() => {
+        isFocused.value = false;
+        query.value = '';
+    }, 100);
+}
+
+function closeDropdown() {
+    isFocused.value = false;
+    query.value = '';
+}
+
+function normalizeValues(values: string[]) {
+    const normalizedValues: string[] = [];
+
+    for (const value of values) {
+        const normalizedValue = value.trim();
+        if (!normalizedValue || normalizedValues.some((existingValue) => existingValue.toLowerCase() === normalizedValue.toLowerCase())) {
+            continue;
+        }
+
+        normalizedValues.push(normalizedValue);
+    }
+
+    return normalizedValues;
+}
+</script>

--- a/src/components/form/InputTagSelect.vue
+++ b/src/components/form/InputTagSelect.vue
@@ -1,0 +1,184 @@
+<template>
+  <div class="relative">
+    <label
+      v-if="label"
+      class="block text-sm text-slate-700"
+    >
+      {{ label }}
+    </label>
+
+    <div class="mt-1 rounded-md border border-slate-300 bg-white px-4 py-2.5 shadow-sm transition focus-within:border-brand-500 focus-within:ring-2 focus-within:ring-brand-200">
+      <div class="flex flex-wrap items-center gap-2">
+        <span
+          v-for="item in selectedItems"
+          :key="item"
+          class="inline-flex items-center gap-1 rounded-md bg-slate-100 px-2.5 py-1 text-sm font-medium text-slate-700"
+        >
+          <span>{{ item }}</span>
+          <button
+            type="button"
+            class="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-sm !bg-transparent !px-0 !py-0 !text-slate-400 !shadow-none transition hover:!bg-slate-200 hover:!text-slate-600"
+            :title="`Remove ${item}`"
+            :aria-label="`Remove ${item}`"
+            @click="removeItem(item)"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              class="h-3 w-3"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 4L12 12M12 4L4 12"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+        </span>
+
+        <input
+          ref="inputRef"
+          v-model="query"
+          type="text"
+          :placeholder="placeholder"
+          :disabled="disabled"
+          class="h-7 min-w-[7rem] flex-1 !border-0 !bg-transparent !px-0 !py-0 text-sm text-slate-900 !shadow-none placeholder:text-slate-400 focus:!ring-0 disabled:cursor-not-allowed disabled:text-slate-400"
+          @focus="isFocused = true"
+          @blur="handleBlur"
+          @keydown.enter.prevent="selectFirstFilteredOption"
+          @keydown.backspace="handleBackspace"
+          @keydown.esc.prevent="closeDropdown"
+        >
+      </div>
+    </div>
+
+    <div
+      v-if="showDropdown"
+      class="absolute z-20 mt-2 max-h-56 w-full overflow-y-auto rounded-md border border-slate-300 bg-white py-2 shadow-xl"
+    >
+      <button
+        v-for="option in filteredOptions"
+        :key="option"
+        type="button"
+        class="flex w-full items-center justify-between bg-transparent px-4 py-2 text-left text-sm text-slate-700 shadow-none outline-none transition hover:bg-slate-50 hover:text-slate-900 focus:bg-slate-50 focus:text-slate-900 focus:outline-none focus-visible:outline-none active:bg-slate-100"
+        @mousedown.prevent="addItem(option)"
+      >
+        <span class="truncate">{{ option }}</span>
+      </button>
+    </div>
+
+    <p
+      v-if="help"
+      class="mt-2 text-sm text-slate-600"
+    >
+      {{ help }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+const props = withDefaults(defineProps<{
+    modelValue: string[];
+    options: string[];
+    label?: string;
+    help?: string;
+    placeholder?: string;
+    disabled?: boolean;
+}>(), {
+    label: '',
+    help: '',
+    placeholder: '',
+    disabled: false,
+});
+
+const emit = defineEmits<{
+    'update:modelValue': [value: string[]];
+}>();
+
+const inputRef = ref<HTMLInputElement | null>(null);
+const isFocused = ref(false);
+const query = ref('');
+
+const normalizedOptions = computed(() => normalizeValues(props.options ?? []));
+const selectedItems = computed(() => normalizeValues(props.modelValue ?? []));
+const filteredOptions = computed(() => {
+    const normalizedQuery = query.value.trim().toLowerCase();
+
+    return normalizedOptions.value.filter((option) => {
+        if (selectedItems.value.includes(option)) {
+            return false;
+        }
+
+        if (!normalizedQuery) {
+            return true;
+        }
+
+        return option.toLowerCase().includes(normalizedQuery);
+    });
+});
+const showDropdown = computed(() => isFocused.value && !props.disabled && filteredOptions.value.length > 0);
+
+function addItem(option: string) {
+    const normalizedOption = normalizedOptions.value.find((value) => value.toLowerCase() === option.toLowerCase());
+    if (!normalizedOption || selectedItems.value.includes(normalizedOption)) {
+        query.value = '';
+        return;
+    }
+
+    emit('update:modelValue', [...selectedItems.value, normalizedOption]);
+    query.value = '';
+    inputRef.value?.focus();
+}
+
+function removeItem(option: string) {
+    emit('update:modelValue', selectedItems.value.filter((value) => value !== option));
+}
+
+function selectFirstFilteredOption() {
+    if (filteredOptions.value.length === 0) {
+        return;
+    }
+
+    addItem(filteredOptions.value[0]);
+}
+
+function handleBackspace(event: KeyboardEvent) {
+    if (query.value || selectedItems.value.length === 0) {
+        return;
+    }
+
+    event.preventDefault();
+    emit('update:modelValue', selectedItems.value.slice(0, -1));
+}
+
+function handleBlur() {
+    window.setTimeout(() => {
+        isFocused.value = false;
+        query.value = '';
+    }, 100);
+}
+
+function closeDropdown() {
+    isFocused.value = false;
+    query.value = '';
+}
+
+function normalizeValues(values: string[]) {
+    const normalizedValues: string[] = [];
+
+    for (const value of values) {
+        const normalizedValue = value.trim();
+        if (!normalizedValue || normalizedValues.some((existingValue) => existingValue.toLowerCase() === normalizedValue.toLowerCase())) {
+            continue;
+        }
+
+        normalizedValues.push(normalizedValue);
+    }
+
+    return normalizedValues;
+}
+</script>

--- a/src/components/settings/CompanyEditorCard.vue
+++ b/src/components/settings/CompanyEditorCard.vue
@@ -112,9 +112,10 @@ import InputSelect from '@/components/form/InputSelect.vue';
 import TrashCanButton from '@/components/form/TrashCanButton.vue';
 import KeyValues, { type KeyValue } from '@/components/KeyValues.vue';
 import { keyValueArrayToDataRecord, keyValuesFromDataRecord, setCompanyDataDraft } from '@/helpers/keyValueMetadata';
+import { getUserCompanyIds, setUserCompanyIds } from '@/helpers/userContext';
 import contextStore from '@/stores/context.store';
 import { ChevronDownIcon } from '@heroicons/vue/24/outline';
-import type { Company } from '@relewise/client';
+import type { Company, User } from '@relewise/client';
 import { computed, ref, watch } from 'vue';
 
 const props = defineProps<{
@@ -122,6 +123,7 @@ const props = defineProps<{
     company: Company;
     expanded: boolean;
     isActive: boolean;
+    users: User[];
 }>();
 
 defineEmits<{
@@ -249,6 +251,17 @@ function commitCompanyIdChange() {
         }
 
         company.parent = nextCompanyId ? props.company : undefined;
+    });
+    props.users.forEach((user) => {
+        const nextCompanyIds = getUserCompanyIds(user).map((companyId) => {
+            if (companyId !== previousCompanyId) {
+                return companyId;
+            }
+
+            return nextCompanyId;
+        });
+
+        setUserCompanyIds(user, nextCompanyIds);
     });
 
     if (props.isActive && contextStore.selectedCompanyId.value === previousCompanyId) {

--- a/src/components/settings/UserEditorCard.vue
+++ b/src/components/settings/UserEditorCard.vue
@@ -132,7 +132,7 @@ import InputText from '@/components/form/InputText.vue';
 import TrashCanButton from '@/components/form/TrashCanButton.vue';
 import KeyValues, { type KeyValue } from '@/components/KeyValues.vue';
 import { keyValueArrayToDataRecord, keyValueArrayToStringRecord, keyValuesFromDataRecord, keyValuesFromStringRecord, setUserMetadataDraft } from '@/helpers/keyValueMetadata';
-import { displayUser } from '@/helpers/userHelper';
+import { displayUserOption } from '@/helpers/userHelper';
 import { getUserCompanyIds, setUserCompanyIds } from '@/helpers/userContext';
 import { ChevronDownIcon } from '@heroicons/vue/24/outline';
 import type { Company } from '@relewise/client';
@@ -144,6 +144,8 @@ const props = defineProps<{
     expanded: boolean;
     isActive: boolean;
     user: User;
+    userIndex: number;
+    users: User[];
 }>();
 
 defineEmits<{
@@ -166,21 +168,11 @@ const identifierValues = computed(() => {
 });
 
 const headline = computed(() => {
-    const preferredLabel = displayUser({
+    return displayUserOption({
         email: email.value.trim() || undefined,
         authenticatedId: authenticatedId.value.trim() || undefined,
         temporaryId: temporaryId.value.trim() || undefined,
-    } as User);
-
-    if (preferredLabel !== 'Anonymous') {
-        return preferredLabel;
-    }
-
-    if (identifierValues.value.length > 0) {
-        return identifierValues.value.join(', ');
-    }
-
-    return 'Anonymous user';
+    } as User, props.userIndex, props.users);
 });
 
 const authenticatedIdActionLabel = computed(() => authenticatedId.value.trim() ? 'Regenerate' : 'Generate');

--- a/src/components/settings/UserEditorCard.vue
+++ b/src/components/settings/UserEditorCard.vue
@@ -109,6 +109,17 @@
           title="Data"
         />
       </div>
+
+      <div class="mt-6 border-t border-slate-200 pt-6">
+        <InputTagSelect
+          v-model="companyIds"
+          :options="availableCompanyIds"
+          label="Companies"
+          placeholder="Select company"
+          :disabled="availableCompanyIds.length === 0"
+          :help="availableCompanyIds.length > 0 ? 'Select one or more companies that can be paired with this user in the context switcher.' : 'Add companies to the dataset before associating them with a user.'"
+        />
+      </div>
     </div>
   </article>
 </template>
@@ -116,16 +127,20 @@
 <script lang="ts" setup>
 /* eslint-disable vue/no-mutating-props */
 import InlineActionInput from '@/components/InlineActionInput.vue';
+import InputTagSelect from '@/components/form/InputTagSelect.vue';
 import InputText from '@/components/form/InputText.vue';
 import TrashCanButton from '@/components/form/TrashCanButton.vue';
 import KeyValues, { type KeyValue } from '@/components/KeyValues.vue';
 import { keyValueArrayToDataRecord, keyValueArrayToStringRecord, keyValuesFromDataRecord, keyValuesFromStringRecord, setUserMetadataDraft } from '@/helpers/keyValueMetadata';
 import { displayUser } from '@/helpers/userHelper';
+import { getUserCompanyIds, setUserCompanyIds } from '@/helpers/userContext';
 import { ChevronDownIcon } from '@heroicons/vue/24/outline';
+import type { Company } from '@relewise/client';
 import type { User } from '@relewise/client';
 import { computed, ref, watch } from 'vue';
 
 const props = defineProps<{
+    companies: Company[];
     expanded: boolean;
     isActive: boolean;
     user: User;
@@ -142,10 +157,7 @@ const data = ref<KeyValue[]>([]);
 const temporaryId = ref('');
 const authenticatedId = ref('');
 const email = ref('');
-
-const firstIdentifier = computed(() => {
-    return identifiers.value.find((entry) => entry.key?.trim() || entry.value?.trim());
-});
+const companyIds = ref<string[]>([]);
 
 const identifierValues = computed(() => {
     return identifiers.value
@@ -173,6 +185,11 @@ const headline = computed(() => {
 
 const authenticatedIdActionLabel = computed(() => authenticatedId.value.trim() ? 'Regenerate' : 'Generate');
 const temporaryIdActionLabel = computed(() => temporaryId.value.trim() ? 'Regenerate' : 'Generate');
+const availableCompanyIds = computed(() => {
+    return props.companies
+        .map((company) => company.id?.trim() ?? '')
+        .filter((companyId, index, companyIds) => companyId && companyIds.indexOf(companyId) === index);
+});
 
 const summaryBadges = computed(() => {
     const badges: string[] = [];
@@ -191,6 +208,10 @@ const summaryBadges = computed(() => {
 
     badges.push(...identifierValues.value);
 
+    if (companyIds.value.length > 0) {
+        badges.push(`Companies: ${companyIds.value.join(', ')}`);
+    }
+
     return badges;
 });
 
@@ -203,12 +224,13 @@ watch(
         classifications.value = keyValuesFromStringRecord(nextUser?.classifications);
         identifiers.value = keyValuesFromStringRecord(nextUser?.identifiers);
         data.value = keyValuesFromDataRecord(nextUser?.data);
+        companyIds.value = getUserCompanyIds(nextUser);
     },
     { immediate: true },
 );
 
 watch(
-    [temporaryId, authenticatedId, email, classifications, identifiers, data],
+    [temporaryId, authenticatedId, email, classifications, identifiers, data, companyIds],
     () => {
         syncUserMetadata();
     },
@@ -228,6 +250,7 @@ function syncUserMetadata() {
     props.user.classifications = keyValueArrayToStringRecord(classifications.value);
     props.user.identifiers = keyValueArrayToStringRecord(identifiers.value);
     props.user.data = keyValueArrayToDataRecord(data.value);
+    setUserCompanyIds(props.user, companyIds.value);
 }
 
 function setAuthenticatedId(value: string) {

--- a/src/components/settings/UserEditorCard.vue
+++ b/src/components/settings/UserEditorCard.vue
@@ -1,8 +1,8 @@
 <template>
-  <article class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+  <article class="relative overflow-visible rounded-2xl border border-slate-200 bg-white shadow-sm">
     <div
       class="flex flex-col gap-4 bg-slate-50 px-6 py-4 md:flex-row md:items-start md:justify-between"
-      :class="expanded ? 'border-b border-slate-200' : ''"
+      :class="expanded ? 'rounded-t-2xl border-b border-slate-200' : 'rounded-2xl'"
     >
       <button
         type="button"
@@ -60,7 +60,7 @@
 
     <div
       v-if="expanded"
-      class="px-6 py-6"
+      class="relative rounded-b-2xl px-6 py-6"
       @click.stop
     >
       <div class="grid gap-5 xl:grid-cols-3">
@@ -109,6 +109,17 @@
           title="Data"
         />
       </div>
+
+      <div class="relative z-20 mt-6 border-t border-slate-200 pt-6">
+        <InputTagSelect
+          v-model="companyIds"
+          :options="availableCompanyIds"
+          label="Companies"
+          placeholder="Select company"
+          :disabled="availableCompanyIds.length === 0"
+          :help="availableCompanyIds.length > 0 ? 'Select one or more companies that can be paired with this user in the context switcher.' : 'Add companies to the dataset before associating them with a user.'"
+        />
+      </div>
     </div>
   </article>
 </template>
@@ -116,16 +127,20 @@
 <script lang="ts" setup>
 /* eslint-disable vue/no-mutating-props */
 import InlineActionInput from '@/components/InlineActionInput.vue';
+import InputTagSelect from '@/components/form/InputTagSelect.vue';
 import InputText from '@/components/form/InputText.vue';
 import TrashCanButton from '@/components/form/TrashCanButton.vue';
 import KeyValues, { type KeyValue } from '@/components/KeyValues.vue';
 import { keyValueArrayToDataRecord, keyValueArrayToStringRecord, keyValuesFromDataRecord, keyValuesFromStringRecord, setUserMetadataDraft } from '@/helpers/keyValueMetadata';
 import { displayUser } from '@/helpers/userHelper';
+import { getUserCompanyIds, setUserCompanyIds } from '@/helpers/userContext';
 import { ChevronDownIcon } from '@heroicons/vue/24/outline';
+import type { Company } from '@relewise/client';
 import type { User } from '@relewise/client';
 import { computed, ref, watch } from 'vue';
 
 const props = defineProps<{
+    companies: Company[];
     expanded: boolean;
     isActive: boolean;
     user: User;
@@ -142,10 +157,7 @@ const data = ref<KeyValue[]>([]);
 const temporaryId = ref('');
 const authenticatedId = ref('');
 const email = ref('');
-
-const firstIdentifier = computed(() => {
-    return identifiers.value.find((entry) => entry.key?.trim() || entry.value?.trim());
-});
+const companyIds = ref<string[]>([]);
 
 const identifierValues = computed(() => {
     return identifiers.value
@@ -173,6 +185,11 @@ const headline = computed(() => {
 
 const authenticatedIdActionLabel = computed(() => authenticatedId.value.trim() ? 'Regenerate' : 'Generate');
 const temporaryIdActionLabel = computed(() => temporaryId.value.trim() ? 'Regenerate' : 'Generate');
+const availableCompanyIds = computed(() => {
+    return props.companies
+        .map((company) => company.id?.trim() ?? '')
+        .filter((companyId, index, companyIds) => companyId && companyIds.indexOf(companyId) === index);
+});
 
 const summaryBadges = computed(() => {
     const badges: string[] = [];
@@ -191,6 +208,10 @@ const summaryBadges = computed(() => {
 
     badges.push(...identifierValues.value);
 
+    if (companyIds.value.length > 0) {
+        badges.push(`Companies: ${companyIds.value.join(', ')}`);
+    }
+
     return badges;
 });
 
@@ -203,12 +224,13 @@ watch(
         classifications.value = keyValuesFromStringRecord(nextUser?.classifications);
         identifiers.value = keyValuesFromStringRecord(nextUser?.identifiers);
         data.value = keyValuesFromDataRecord(nextUser?.data);
+        companyIds.value = getUserCompanyIds(nextUser);
     },
     { immediate: true },
 );
 
 watch(
-    [temporaryId, authenticatedId, email, classifications, identifiers, data],
+    [temporaryId, authenticatedId, email, classifications, identifiers, data, companyIds],
     () => {
         syncUserMetadata();
     },
@@ -228,6 +250,7 @@ function syncUserMetadata() {
     props.user.classifications = keyValueArrayToStringRecord(classifications.value);
     props.user.identifiers = keyValueArrayToStringRecord(identifiers.value);
     props.user.data = keyValueArrayToDataRecord(data.value);
+    setUserCompanyIds(props.user, companyIds.value);
 }
 
 function setAuthenticatedId(value: string) {

--- a/src/components/settings/UserEditorCard.vue
+++ b/src/components/settings/UserEditorCard.vue
@@ -224,9 +224,16 @@ watch(
         classifications.value = keyValuesFromStringRecord(nextUser?.classifications);
         identifiers.value = keyValuesFromStringRecord(nextUser?.identifiers);
         data.value = keyValuesFromDataRecord(nextUser?.data);
-        companyIds.value = getUserCompanyIds(nextUser);
     },
     { immediate: true },
+);
+
+watch(
+    [availableCompanyIds, () => getUserCompanyIds(props.user)],
+    () => {
+        syncCompanyIdsFromProps();
+    },
+    { immediate: true, deep: true },
 );
 
 watch(
@@ -253,6 +260,17 @@ function syncUserMetadata() {
     setUserCompanyIds(props.user, companyIds.value);
 }
 
+function syncCompanyIdsFromProps() {
+    const validCompanyIds = new Set(availableCompanyIds.value);
+    const nextCompanyIds = getUserCompanyIds(props.user).filter((companyId) => validCompanyIds.has(companyId));
+
+    if (areSameStringArrays(companyIds.value, nextCompanyIds)) {
+        return;
+    }
+
+    companyIds.value = nextCompanyIds;
+}
+
 function setAuthenticatedId(value: string) {
     authenticatedId.value = value;
 }
@@ -270,6 +288,14 @@ function formatBadgeValue(key?: string | null, value?: string | null) {
     }
 
     return trimmedValue || trimmedKey;
+}
+
+function areSameStringArrays(left: string[], right: string[]) {
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((value, index) => value === right[index]);
 }
 
 </script>

--- a/src/helpers/contextSession.ts
+++ b/src/helpers/contextSession.ts
@@ -85,18 +85,11 @@ export function normalizeSessionSelectionsForDataset(dataset: IDataset | undefin
     const selectedUser = users[normalizedSelections.selectedUserIndex];
     const validCompanyIds = getSelectableCompanyIdsForUser(selectedUser, dataset);
     if (validCompanyIds.length === 0) {
-        normalizedSelections.selectedUserIndex = undefined;
         normalizedSelections.selectedCompanyId = undefined;
         return normalizedSelections;
     }
 
-    if (validCompanyIds.length === 1) {
-        normalizedSelections.selectedCompanyId = validCompanyIds[0];
-        return normalizedSelections;
-    }
-
-    if (!normalizedSelections.selectedCompanyId || !validCompanyIds.includes(normalizedSelections.selectedCompanyId)) {
-        normalizedSelections.selectedUserIndex = undefined;
+    if (normalizedSelections.selectedCompanyId && !validCompanyIds.includes(normalizedSelections.selectedCompanyId)) {
         normalizedSelections.selectedCompanyId = undefined;
     }
 

--- a/src/helpers/contextSession.ts
+++ b/src/helpers/contextSession.ts
@@ -1,4 +1,6 @@
 import type { IDataset } from '@/stores/context.store';
+import { getUserCompanyIds } from '@/helpers/userContext';
+import type { User } from '@relewise/client';
 
 export interface SessionSelections {
     selectedLanguage?: string;
@@ -33,11 +35,13 @@ export function createSessionSelectionsForDataset(dataset?: IDataset): SessionSe
 
     reportMissingLocaleConfiguration(dataset);
 
+    const validUserSelection = getDefaultUserSelection(dataset);
+
     return {
         selectedLanguage: dataset.allLanguages?.[0] ?? undefined,
         selectedCurrencyCode: dataset.allCurrencies?.[0] ?? undefined,
-        selectedUserIndex: (dataset.users?.length ?? 0) > 0 ? 0 : undefined,
-        selectedCompanyId: dataset.companies?.[0]?.id || undefined,
+        selectedUserIndex: validUserSelection.selectedUserIndex,
+        selectedCompanyId: validUserSelection.selectedCompanyId,
     };
 }
 
@@ -73,10 +77,66 @@ export function normalizeSessionSelectionsForDataset(dataset: IDataset | undefin
         normalizedSelections.selectedUserIndex = undefined;
     }
 
-    const companies = dataset.companies ?? [];
-    if (!normalizedSelections.selectedCompanyId || !companies.some((company) => company.id === normalizedSelections.selectedCompanyId)) {
+    if (normalizedSelections.selectedUserIndex === undefined) {
+        normalizedSelections.selectedCompanyId = undefined;
+        return normalizedSelections;
+    }
+
+    const selectedUser = users[normalizedSelections.selectedUserIndex];
+    const validCompanyIds = getSelectableCompanyIdsForUser(selectedUser, dataset);
+    if (validCompanyIds.length === 0) {
+        normalizedSelections.selectedUserIndex = undefined;
+        normalizedSelections.selectedCompanyId = undefined;
+        return normalizedSelections;
+    }
+
+    if (validCompanyIds.length === 1) {
+        normalizedSelections.selectedCompanyId = validCompanyIds[0];
+        return normalizedSelections;
+    }
+
+    if (!normalizedSelections.selectedCompanyId || !validCompanyIds.includes(normalizedSelections.selectedCompanyId)) {
+        normalizedSelections.selectedUserIndex = undefined;
         normalizedSelections.selectedCompanyId = undefined;
     }
 
     return normalizedSelections;
+}
+
+export function getSelectableCompanyIdsForUser(user: User | undefined, dataset?: IDataset) {
+    if (!user || !dataset) {
+        return [];
+    }
+
+    const knownCompanyIds = new Set((dataset.companies ?? []).map((company) => company.id).filter(Boolean));
+    return getUserCompanyIds(user).filter((companyId) => knownCompanyIds.has(companyId));
+}
+
+export function hasSelectableCompaniesForUser(user: User | undefined, dataset?: IDataset) {
+    return getSelectableCompanyIdsForUser(user, dataset).length > 0;
+}
+
+function getDefaultUserSelection(dataset: IDataset) {
+    const users = dataset.users ?? [];
+
+    for (const [index, user] of users.entries()) {
+        const selectableCompanyIds = getSelectableCompanyIdsForUser(user, dataset);
+        if (selectableCompanyIds.length === 0) {
+            continue;
+        }
+
+        if (selectableCompanyIds.length === 1) {
+            return {
+                selectedUserIndex: index,
+                selectedCompanyId: selectableCompanyIds[0],
+            };
+        }
+
+        break;
+    }
+
+    return {
+        selectedUserIndex: undefined,
+        selectedCompanyId: undefined,
+    };
 }

--- a/src/helpers/contextSession.ts
+++ b/src/helpers/contextSession.ts
@@ -111,21 +111,11 @@ export function hasSelectableCompaniesForUser(user: User | undefined, dataset?: 
 
 function getDefaultUserSelection(dataset: IDataset) {
     const users = dataset.users ?? [];
-
-    for (const [index, user] of users.entries()) {
-        const selectableCompanyIds = getSelectableCompanyIdsForUser(user, dataset);
-        if (selectableCompanyIds.length === 0) {
-            continue;
-        }
-
-        if (selectableCompanyIds.length === 1) {
-            return {
-                selectedUserIndex: index,
-                selectedCompanyId: selectableCompanyIds[0],
-            };
-        }
-
-        break;
+    if (users.length > 0) {
+        return {
+            selectedUserIndex: 0,
+            selectedCompanyId: undefined,
+        };
     }
 
     return {

--- a/src/helpers/contextSummary.ts
+++ b/src/helpers/contextSummary.ts
@@ -1,4 +1,5 @@
 import { displayUser } from '@/helpers/userHelper';
+import { getUserCompanyIds } from '@/helpers/userContext';
 import type { Company, User } from '@relewise/client';
 
 export function getSelectedUser(users: User[] | undefined, selectedUserIndex: number | undefined) {
@@ -49,6 +50,11 @@ export function formatUserDetails(user: User | undefined) {
         if (key && value?.value) {
             details.push(`Data ${key}: ${String(value.value)}`);
         }
+    }
+
+    const companyIds = getUserCompanyIds(user);
+    if (companyIds.length > 0) {
+        details.push(`Companies: ${companyIds.join(', ')}`);
     }
 
     return details.length > 0 ? details.join('\n') : 'Anonymous user';

--- a/src/helpers/personalizationValidation.ts
+++ b/src/helpers/personalizationValidation.ts
@@ -1,5 +1,6 @@
 import type { IDataset } from '@/stores/context.store';
 import { getCompanyDataDraft, getUserMetadataDraft, hasDuplicateKeyValueKeys, hasIncompleteKeyValueRows } from '@/helpers/keyValueMetadata';
+import { getUserCompanyIds } from '@/helpers/userContext';
 import type { Company, DataValue } from '@relewise/client';
 
 export function validatePersonalization(dataset: IDataset) {
@@ -48,6 +49,14 @@ export function validatePersonalization(dataset: IDataset) {
     });
     if (hasDuplicateUserDataKeys) {
         errors.push('User data keys must be unique within the same user.');
+    }
+
+    const validCompanyIds = new Set(companies.map((company) => company.id?.trim()).filter(Boolean));
+    const hasUnknownUserCompanyReference = users.some((user) => {
+        return getUserCompanyIds(user).some((companyId) => !validCompanyIds.has(companyId));
+    });
+    if (hasUnknownUserCompanyReference) {
+        errors.push('All user company associations must reference companies in the dataset.');
     }
 
     if (hasDuplicateValues(users, (user) => user.temporaryId?.trim())) {

--- a/src/helpers/sharedDataset.ts
+++ b/src/helpers/sharedDataset.ts
@@ -2,7 +2,7 @@ import { formatCompanyDetails, formatUserDetails } from '@/helpers/contextSummar
 import { normalizeDatasetConfiguration, sanitizeCompanies, uniqueNormalizedStrings } from '@/helpers/datasetConfiguration';
 import { datasetFeatureFields, type DatasetBooleanKey } from '@/helpers/datasetFeatures';
 import { displayUser } from '@/helpers/userHelper';
-import { sanitizeUser, sanitizeUsers } from '@/helpers/userContext';
+import { getUserCompanyIds, sanitizeUser, sanitizeUsers } from '@/helpers/userContext';
 import type { IDataset } from '@/stores/context.store';
 import type { Company, DataValue, User } from '@relewise/client';
 
@@ -633,6 +633,7 @@ function createComparableUserKey(user: User) {
         classifications: normalizeComparableStringRecord(comparableUser.classifications),
         identifiers: normalizeComparableStringRecord(comparableUser.identifiers),
         data: normalizeComparableDataRecord(comparableUser.data),
+        companyIds: getUserCompanyIds(comparableUser).sort((leftValue, rightValue) => leftValue.localeCompare(rightValue)),
     });
 }
 

--- a/src/helpers/userContext.ts
+++ b/src/helpers/userContext.ts
@@ -1,20 +1,68 @@
 import type { Company, User } from '@relewise/client';
 
+export type DemoUser = User & {
+    companyIds?: string[];
+};
+
+function normalizeCompanyIds(companyIds: Array<string | undefined | null> = []) {
+    const normalizedCompanyIds: string[] = [];
+
+    for (const companyId of companyIds) {
+        const normalizedCompanyId = companyId?.trim() ?? '';
+        if (!normalizedCompanyId || normalizedCompanyIds.some((existingCompanyId) => existingCompanyId.toLowerCase() === normalizedCompanyId.toLowerCase())) {
+            continue;
+        }
+
+        normalizedCompanyIds.push(normalizedCompanyId);
+    }
+
+    return normalizedCompanyIds;
+}
+
+export function getUserCompanyIds(user: User | undefined) {
+    if (!user) {
+        return [];
+    }
+
+    return normalizeCompanyIds((user as DemoUser).companyIds);
+}
+
+export function setUserCompanyIds(user: User, companyIds: string[]) {
+    const normalizedCompanyIds = normalizeCompanyIds(companyIds);
+
+    if (normalizedCompanyIds.length === 0) {
+        delete (user as DemoUser).companyIds;
+        return;
+    }
+
+    (user as DemoUser).companyIds = normalizedCompanyIds;
+}
+
 export function sanitizeUser(user: User) {
-    const normalizedUser: User = {
+    const normalizedUser: DemoUser = {
         ...user,
         classifications: user.classifications ? { ...user.classifications } : undefined,
         identifiers: user.identifiers ? { ...user.identifiers } : undefined,
         data: user.data ? { ...user.data } : undefined,
+        companyIds: getUserCompanyIds(user),
     };
 
     delete normalizedUser.company;
+    if ((normalizedUser.companyIds?.length ?? 0) === 0) {
+        delete normalizedUser.companyIds;
+    }
 
     return normalizedUser;
 }
 
 export function sanitizeUsers(users?: User[]) {
     return (users ?? []).map(sanitizeUser);
+}
+
+function sanitizeRuntimeUser(user: User) {
+    const normalizedUser = sanitizeUser(user);
+    delete normalizedUser.companyIds;
+    return normalizedUser as User;
 }
 
 function buildRuntimeCompany(company: Company | undefined, companies: Company[]) {
@@ -48,7 +96,7 @@ function buildRuntimeCompany(company: Company | undefined, companies: Company[])
 }
 
 export function buildContextUser(user: User | undefined, company: Company | undefined, companies: Company[] = []) {
-    const baseUser = user ? sanitizeUser(user) : {};
+    const baseUser = user ? sanitizeRuntimeUser(user) : {};
 
     return {
         ...baseUser,

--- a/src/helpers/userHelper.ts
+++ b/src/helpers/userHelper.ts
@@ -17,12 +17,26 @@ export const displayUser = (user: User | null | undefined) => {
     return 'Anonymous';
 };
 
-export const displayUserOption = (user: User | null | undefined, index: number) => {
+function isAnonymousUser(user: User | null | undefined) {
+    return displayUser(user) === 'Anonymous';
+}
+
+export const displayUserOption = (user: User | null | undefined, index: number, users: User[] = []) => {
     const label = displayUser(user);
 
     if (label !== 'Anonymous') {
         return label;
     }
 
-    return `Anonymous user ${index + 1}`;
+    const anonymousUsers = users.filter((candidateUser) => isAnonymousUser(candidateUser));
+    if (anonymousUsers.length <= 1) {
+        return 'Anonymous user';
+    }
+
+    const anonymousUserIndex = users
+        .slice(0, index + 1)
+        .filter((candidateUser) => isAnonymousUser(candidateUser))
+        .length;
+
+    return anonymousUserIndex <= 1 ? 'Anonymous user' : `Anonymous user (${anonymousUserIndex})`;
 };

--- a/src/layout/Header.vue
+++ b/src/layout/Header.vue
@@ -26,8 +26,8 @@ const activeUser = computed(() => {
     return getSelectedUser(currentUsers.value, contextStore.selectedUserIndex.value);
 });
 const activeUserDetails = computed(() => formatUserDetails(activeUser.value));
-const hasConfiguredCompanies = computed(() => (contextStore.context.value?.companies?.length ?? 0) > 0);
-const activeCompanyLabel = computed(() => contextStore.selectedCompany.value?.id || '(None)');
+const hasSelectedCompany = computed(() => !!contextStore.selectedCompany.value);
+const activeCompanyLabel = computed(() => contextStore.selectedCompany.value?.id ?? '');
 const activeCompanyDetails = computed(() => formatCompanyDetails(contextStore.selectedCompany.value));
 </script>
 
@@ -120,7 +120,7 @@ const activeCompanyDetails = computed(() => formatCompanyDetails(contextStore.se
                         <span class="max-w-[10rem] truncate">User: {{ activeUserLabel }}</span>
                       </span>
                       <span
-                        v-if="hasConfiguredCompanies"
+                        v-if="hasSelectedCompany"
                         class="inline-flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-600"
                         :title="activeCompanyDetails"
                       >

--- a/src/stores/context.store.ts
+++ b/src/stores/context.store.ts
@@ -326,6 +326,7 @@ class AppContext {
 
     public setUserSelection(selectedUserIndex: number | undefined) {
         this.state.selectedUserIndex = selectedUserIndex;
+        this.normalizeSessionSelections();
         basketService.clear();
         this.persistState();
     }
@@ -373,6 +374,8 @@ class AppContext {
 
     public setCompany(companyId: string) {
         this.state.selectedCompanyId = companyId || undefined;
+        this.normalizeSessionSelections();
+        this.persistState();
     }
 
     public deleteSelectedUser() {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -137,7 +137,9 @@ async function init() {
         }
         activateImportedDataset(existingDataset.datasetId, sharedDataset);
         await reloadAtRoute(
-            { name: 'settings-dataset', params: { datasetId: existingDataset.datasetId } },
+            diff.hasChanges
+                ? { name: 'settings-dataset', params: { datasetId: existingDataset.datasetId } }
+                : { name: 'home' },
             { type: 'success', title: diff.hasChanges ? 'Shared dataset applied.' : 'Dataset already up to date.' },
         );
         return;


### PR DESCRIPTION
https://trello.com/c/ZRGPAsXT/19770-demo-company-dropdown-on-front-end-never-changes-when-switching-users

## Summary
- add persisted per-user company associations and enforce valid user/company combinations in the context switcher
- update share-link import handling so unchanged existing datasets activate and route to `/`
- add a company tag-select editor for users and place it below the existing user detail sections

## Validation
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm run test:unit -- --run` *(fails because the repository currently has no test files)*